### PR TITLE
Implement JPX Excel parser and tests

### DIFF
--- a/setouchi/__init__.py
+++ b/setouchi/__init__.py
@@ -1,0 +1,2 @@
+"""Setouchi package for financial document processing."""
+

--- a/setouchi/jpx_excel.py
+++ b/setouchi/jpx_excel.py
@@ -1,0 +1,90 @@
+"""Utilities for parsing JPX English disclosure Excel list.
+
+This module follows the design specified in ``design.md`` for detecting the header
+row and extracting companies whose "Annual Securities Reports" disclosure status is
+``Available``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+
+def _normalize_columns(columns: List[str]) -> List[str]:
+    """Normalize column names by stripping, lowering and converting to string."""
+    return [str(c).strip().lower() for c in columns]
+
+
+def detect_header_row(path: str | Path, max_rows: int = 10) -> int:
+    """Detect the header row in the Excel file.
+
+    The header row is defined as the first row within ``max_rows`` that contains both
+    ``"annual securities reports"`` and ``"disclosure status"`` in its column names.
+
+    Parameters
+    ----------
+    path:
+        Path to the Excel file.
+    max_rows:
+        Number of initial rows to search for the header.
+
+    Returns
+    -------
+    int
+        Zero-based index of the header row.
+
+    Raises
+    ------
+    ValueError
+        If no suitable header row is found within ``max_rows`` rows.
+    """
+    path = Path(path)
+    for r in range(max_rows):
+        df = pd.read_excel(path, header=r, nrows=0)
+        cols = _normalize_columns(df.columns)
+        joined = " ".join(cols)
+        if "annual securities reports" in joined and "disclosure status" in joined:
+            return r
+    raise ValueError("Could not detect header row containing required columns")
+
+
+def extract_available_companies(path: str | Path, max_rows: int = 10) -> pd.DataFrame:
+    """Extract rows where Annual Securities Reports are marked as available.
+
+    Parameters
+    ----------
+    path:
+        Path to the JPX Excel file.
+    max_rows:
+        Number of initial rows to search for the header.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing rows with ``Disclosure Status`` of ``Available``.
+    """
+    header_row = detect_header_row(path, max_rows=max_rows)
+    df = pd.read_excel(path, header=header_row)
+    # Normalize column names for lookup while preserving original DataFrame
+    cols = _normalize_columns(df.columns)
+    df.columns = cols
+    if "disclosure status" not in df.columns:
+        raise ValueError("'Disclosure Status' column not found after normalization")
+    mask = df["disclosure status"].astype(str).str.strip().str.lower() == "available"
+    return df[mask].reset_index(drop=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract companies with available ASR")
+    parser.add_argument("excel_path", help="Path to JPX English disclosure Excel file")
+    args = parser.parse_args()
+
+    available = extract_available_companies(args.excel_path)
+    if available.empty:
+        print("No companies with available Annual Securities Reports found.")
+    else:
+        print(available.to_csv(index=False))

--- a/tests/test_jpx_excel.py
+++ b/tests/test_jpx_excel.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from pathlib import Path
+
+from setouchi.jpx_excel import detect_header_row, extract_available_companies
+
+
+def create_sample_excel(path: Path) -> None:
+    """Create a sample Excel file with header not on the first row."""
+    # Rows before header
+    pre_header = pd.DataFrame({"A": ["foo"], "B": ["bar"]})
+    header = ["Company", "Annual Securities Reports", "Disclosure Status"]
+    data = [
+        ["Alpha Corp", "2023", "Available"],
+        ["Beta Inc", "2023", "Not Available"],
+    ]
+    with pd.ExcelWriter(path) as writer:
+        pre_header.to_excel(writer, index=False, header=False)
+        pd.DataFrame(data, columns=header).to_excel(writer, index=False)
+
+
+def test_detect_header_row(tmp_path: Path) -> None:
+    excel = tmp_path / "sample.xlsx"
+    create_sample_excel(excel)
+    assert detect_header_row(excel) == 1
+
+
+def test_extract_available_companies(tmp_path: Path) -> None:
+    excel = tmp_path / "sample.xlsx"
+    create_sample_excel(excel)
+    result = extract_available_companies(excel)
+    assert len(result) == 1
+    assert result.iloc[0]["company"] == "Alpha Corp"


### PR DESCRIPTION
## Summary
- add JPX Excel utilities to detect header rows and extract companies with available Annual Securities Reports
- cover header detection and filtering logic with unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689753c2f73c83229ee53c0dd300dab4