### PR TITLE
Implement section heading normalisation utilities

### DIFF
--- a/setouchi/__init__.py
+++ b/setouchi/__init__.py
@@ -1,2 +1,26 @@
-"""Setouchi package for financial document processing."""
+"""Setouchi package for financial document processing.
+
+Only a tiny subset of the full design is implemented for the kata.  The
+public API re-exports helpers for working with JPX Excel files, fiscal
+year normalisation and section heading detection.
+"""
+
+from .fiscal import normalize_fiscal_year_end
+from .jpx_excel import extract_available_companies, detect_header_row
+from .section import normalise_section_heading
+from .qa import (
+    extract_numeric_tokens,
+    find_note_references,
+    check_table_column_consistency,
+)
+
+__all__ = [
+    "normalize_fiscal_year_end",
+    "extract_available_companies",
+    "detect_header_row",
+    "normalise_section_heading",
+    "extract_numeric_tokens",
+    "find_note_references",
+    "check_table_column_consistency",
+]
 

--- a/setouchi/qa.py
+++ b/setouchi/qa.py
@@ -1,0 +1,56 @@
+"""Basic QA utilities for document consistency checks.
+
+This module implements simple helpers outlined in ``design.md`` section 16.4
+for automated validation of translated Annual Securities Reports.  The
+functions focus on three aspects:
+
+* extracting numeric tokens (including percentages)
+* detecting note references (``Note 5`` / ``注 5``)
+* verifying that Markdown tables have consistent column counts
+"""
+from __future__ import annotations
+
+import re
+from typing import List
+
+_NUMERIC_RE = re.compile(r"[-+]?\d[\d,]*(?:\.\d+)?%?")
+_NOTE_RE = re.compile(r"(?:注\s*\d+|Note\s*\d+)", re.I)
+
+
+def extract_numeric_tokens(text: str) -> List[str]:
+    """Return a list of numeric tokens found in ``text``.
+
+    The regex roughly mirrors the pattern suggested in the design document,
+    capturing optional sign, commas, decimal parts and trailing percentage
+    symbols.
+    """
+    if not text:
+        return []
+    return _NUMERIC_RE.findall(text)
+
+
+def find_note_references(text: str) -> List[str]:
+    """Detect note references such as ``Note 5`` or ``注 5`` within ``text``."""
+    if not text:
+        return []
+    return _NOTE_RE.findall(text)
+
+
+def check_table_column_consistency(table: str) -> bool:
+    """Check whether all rows in a Markdown table have the same column count."""
+    counts: List[int] = []
+    for line in table.splitlines():
+        if "|" not in line:
+            continue
+        parts = [c.strip() for c in line.strip().strip("|").split("|")]
+        if not any(parts):
+            continue
+        counts.append(len(parts))
+    return len(set(counts)) <= 1
+
+
+__all__ = [
+    "extract_numeric_tokens",
+    "find_note_references",
+    "check_table_column_consistency",
+]

--- a/setouchi/section.py
+++ b/setouchi/section.py
@@ -1,0 +1,97 @@
+"""Utilities for normalising section headings.
+
+This module implements a tiny portion of the design document's
+``Section Heading Normalisation`` (section 16.3).  A heading is mapped to
+one of the predefined ``section_key`` values by fuzzy matching against
+known aliases.  When multiple candidates exceed the threshold the
+``SECTION_PRIORITY`` list resolves conflicts.
+"""
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+from typing import Dict, Iterable, Optional
+
+# Predefined dictionary of section keys and their heading aliases.
+SECTION_ALIASES: Dict[str, Iterable[str]] = {
+    "business_overview": ["business overview", "business description"],
+    "risk_factors": ["risk factors", "risks"],
+    "management_analysis": [
+        "management analysis",
+        "management's discussion and analysis",
+        "management's discussion & analysis",
+        "md&a",
+    ],
+    "sustainability": ["sustainability", "esg"],
+    "r_and_d": ["research and development", "research & development", "r&d"],
+    "corporate_governance": ["corporate governance", "corporate governance report"],
+}
+
+# Priority list for resolving conflicts when multiple section keys match
+# with equal scores.  Earlier entries take precedence.
+SECTION_PRIORITY = [
+    "management_analysis",
+    "business_overview",
+    "risk_factors",
+    "sustainability",
+    "r_and_d",
+    "corporate_governance",
+]
+
+
+def _best_alias_score(text: str, aliases: Iterable[str]) -> float:
+    """Return the best fuzzy match score for ``text`` among ``aliases``."""
+    text_l = text.lower()
+    best = 0.0
+    for alias in aliases:
+        score = SequenceMatcher(None, text_l, alias.lower()).ratio()
+        if score > best:
+            best = score
+    return best
+
+
+def normalise_section_heading(
+    heading: str, *, threshold: float = 0.8
+) -> Optional[str]:
+    """Return the ``section_key`` for ``heading`` if confidently matched.
+
+    Parameters
+    ----------
+    heading:
+        Raw heading string obtained from a report.
+    threshold:
+        Minimum similarity score required to accept a match.  Default is
+        ``0.8`` as referenced in the design document.
+
+    Returns
+    -------
+    str | None
+        The canonical section key, or ``None`` when no alias meets the
+        threshold.
+    """
+    if not heading:
+        return None
+
+    scores = []
+    for key, aliases in SECTION_ALIASES.items():
+        best = _best_alias_score(heading, aliases)
+        if best >= threshold:
+            scores.append((best, key))
+
+    if not scores:
+        return None
+
+    # Determine the maximum score and gather all keys achieving it.
+    max_score = max(score for score, _ in scores)
+    candidates = [key for score, key in scores if score == max_score]
+    if len(candidates) == 1:
+        return candidates[0]
+
+    # Resolve ties using priority order.
+    for key in SECTION_PRIORITY:
+        if key in candidates:
+            return key
+
+    return candidates[0]
+
+
+__all__ = ["normalise_section_heading", "SECTION_ALIASES", "SECTION_PRIORITY"]

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -1,0 +1,24 @@
+import pytest
+
+from setouchi import (
+    extract_numeric_tokens,
+    find_note_references,
+    check_table_column_consistency,
+)
+
+
+def test_extract_numeric_tokens():
+    text = "Revenue increased to 1,234 million yen, up 10% from 1,100."
+    assert extract_numeric_tokens(text) == ["1,234", "10%", "1,100"]
+
+
+def test_find_note_references():
+    text = "See Note 5 and 注 7 for details."
+    assert find_note_references(text) == ["Note 5", "注 7"]
+
+
+def test_check_table_column_consistency():
+    table = """| A | B | C |\n|---|---|---|\n|1|2|3|"""
+    assert check_table_column_consistency(table)
+    bad = """| A | B |\n|---|---|\n|1|2|3|"""
+    assert not check_table_column_consistency(bad)

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,0 +1,16 @@
+import pytest
+
+from setouchi.section import normalise_section_heading
+
+
+def test_exact_match_business_overview():
+    assert normalise_section_heading("Business Overview") == "business_overview"
+
+
+def test_fuzzy_match_management_analysis():
+    heading = "Managements Discussion & Analysis"
+    assert normalise_section_heading(heading) == "management_analysis"
+
+
+def test_no_match_returns_none():
+    assert normalise_section_heading("Completely unrelated heading") is None


### PR DESCRIPTION
## Summary
- add fuzzy section-heading normaliser with alias dictionary and priority-based conflict handling
- expose new helper via package public API and document purpose
- test heading matching for exact, fuzzy and unmatched cases
- add basic QA utilities for numeric tokens, note references and Markdown table column consistency

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a636a7dc83228e9dc5d1bce90632